### PR TITLE
Add catch for both '...' and HTML entity hellip

### DIFF
--- a/themes/evolved-child-theme/functions.php
+++ b/themes/evolved-child-theme/functions.php
@@ -46,7 +46,7 @@ function my_class_names( $classes ) {
  * Remove brakcets from ellipse
  */
 function excerpt_ellipse( $text ) {
-  return str_replace( '[...]', '&#8230;', $text );
+  return str_replace( array( '[...]', '[&hellip;]' ), '&#8230;', $text );
 }
 add_filter( 'get_the_excerpt', 'excerpt_ellipse' );
 


### PR DESCRIPTION
From (possibly) WP v3.6 the [...] is replaced with [& hellip;], at least some of the time.  This PR will catch both.
