### PR TITLE
Fix display thumbnails function

### DIFF
--- a/themes/evolved-child-theme/functions/display-post-thumbnails.php
+++ b/themes/evolved-child-theme/functions/display-post-thumbnails.php
@@ -57,7 +57,7 @@ function display_post_thumbnail( $id = 0, $size = 'thumbnail' ) {
       $img_src  = DEFAULT_PHOTO;
     } else {
       $class    = '';
-      $img_src  = display_post_thumbnail_src();
+      $img_src  = display_post_thumbnail_src( $post_id, $size );
     }
 
     echo '<a href="' . $link . '" title="Permanent Link to ' . esc_attr( get_the_title( $post_id ) ) . '" class="post-thumb' . $class . '" itemprop="image"><img src="' . $img_src . '" alt="' . esc_attr( get_the_title( $post_id ) ) . '" class="attachment-post-thumbnail wp-post-image"></a>';


### PR DESCRIPTION
This function stopped displaying thumbnails somewhere along the way. `display_post_thumbnail_src()` was creating an array of urls to thumbnails in the post, and `display_post_thumbnail()` had a mysterious `$src` param with a value that could never be equivalent to the output of `display_post_thumbnail_src()`. So it displayed nothing. This fix gives us one image url or the `DEFAULT_PHOTO` constant returned from `display_post_thumbnail_src()`, and `display_post_thumbnail()` checks if `display_post_thumbnail_src()` has a value and displays it along with the right class.
