### PR TITLE
Updated pagination function

### DIFF
--- a/themes/evolved-child-theme/functions/pagination.php
+++ b/themes/evolved-child-theme/functions/pagination.php
@@ -25,7 +25,7 @@ function pagination( $query = '', $paged = '', $pages = '', $range = 2 ) {
   }
 
   if ( $paged == '' ) {
-    $paged = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;
+    $paged = ( get_query_var( 'page' ) ) ? get_query_var( 'page' ) : 1;
   }
 
   if ( $pages == '' ) {


### PR DESCRIPTION
Adds variables for pagination with WP_Queries and pass existing data
### Changes
- Added `$query` argument
- Added `$paged` argument
### Testing
1. Create a page with a custom WP_Query
2. Declare the $paged val
3. Use `pagination()` before the `wp_reset_postdata` with the query and paged values as arguments

ex.

```
$paged  = ( get_query_var( 'paged' ) ) ? get_query_var( 'paged' ) : 1;

$post_args  = array(
  'paged'            => $paged,
  'post_type'      => 'post',
  'orderby'         => 'date',
  'order'             => 'DESC',
  'posts_per_page'  => 10,
);

$post_query = new WP_Query( $post_args );
// WP Loop would go here

if ( function_exists( 'pagination' ) ) { pagination( $post_query, $paged, ); }
wp_reset_postdata();
```
### Review

@germanny 
@ericrasch 
@jameswlane 
@weeirishman 
### Notes
- Currently the function assumes query is named `$wp_query`breaking when correct naming practices are followed
- Currently the function assumes the paged variable is named `$paged` and that it has been declared (not always true on search result or category pages)
