### PR TITLE
Adjust block-list border property

### DIFF
--- a/themes/evolved-child-theme/assets/src/scss/objects/_block-list.scss
+++ b/themes/evolved-child-theme/assets/src/scss/objects/_block-list.scss
@@ -28,7 +28,7 @@
   }
 
   > li {
-    border-bottom: 1px;
+    border-bottom-width: 1px;
     padding: $half-spacing-unit;
   }
 }


### PR DESCRIPTION
It's difficult to override the block-list border properties in custom stylesheets. This makes it easier.
